### PR TITLE
fixup rsa pkcs1v15 quote verification

### DIFF
--- a/tss-esapi/Cargo.toml
+++ b/tss-esapi/Cargo.toml
@@ -80,3 +80,7 @@ integration-tests = ["strum", "strum_macros"]
 
 rustcrypto = ["digest", "ecdsa", "elliptic-curve", "pkcs8", "signature", "x509-cert"]
 rustcrypto-full = ["rustcrypto", "p192", "p224", "p256", "p384", "p521", "rsa", "sha1", "sha2", "sha3", "sm2", "sm3"]
+
+sha1 = ["dep:sha1", "rsa?/sha1"]
+sha2 = ["dep:sha2", "rsa?/sha2"]
+

--- a/tss-esapi/src/utils/mod.rs
+++ b/tss-esapi/src/utils/mod.rs
@@ -23,6 +23,17 @@ use crate::{Context, Error, Result, WrapperErrorKind};
 use std::convert::TryFrom;
 use zeroize::Zeroize;
 
+#[cfg(all(
+    any(feature = "p256", feature = "rsa",),
+    any(feature = "sha1", feature = "sha2",)
+))]
+mod quote;
+#[cfg(all(
+    any(feature = "p256", feature = "rsa",),
+    any(feature = "sha1", feature = "sha2",)
+))]
+pub use quote::checkquote;
+
 /// Create the [Public] structure for a restricted decryption key.
 ///
 /// * `symmetric` - Cipher to be used for decrypting children of the key

--- a/tss-esapi/src/utils/quote.rs
+++ b/tss-esapi/src/utils/quote.rs
@@ -323,7 +323,7 @@ pub fn checkquote(
                 ($curve: ty) => {
                     if parameters.ecc_curve() == <$curve>::TPM_CURVE {
                         let Signature::EcDsa(sig) = signature else {
-                            return Ok(false);
+                            return Err(Error::WrapperError(WrapperErrorKind::UnsupportedParam));
                         };
                         if !verify_ecdsa::<$curve>(&public, &bytes, &sig, sig.hashing_algorithm())?
                         {
@@ -351,7 +351,7 @@ pub fn checkquote(
         #[cfg(feature = "rsa")]
         (Public::Rsa { .. }, sig @ Signature::RsaSsa(pkcs_sig)) => {
             let Ok(sig) = pkcs1v15::Signature::try_from(sig.clone()) else {
-                return Ok(false);
+                return Err(Error::WrapperError(WrapperErrorKind::UnsupportedParam));
             };
 
             if !verify_rsa_pkcs1v15(public, &bytes, &sig, pkcs_sig.hashing_algorithm())? {
@@ -362,7 +362,7 @@ pub fn checkquote(
         #[cfg(feature = "rsa")]
         (Public::Rsa { .. }, sig @ Signature::RsaPss(pkcs_sig)) => {
             let Ok(sig) = pss::Signature::try_from(sig.clone()) else {
-                return Ok(false);
+                return Err(Error::WrapperError(WrapperErrorKind::UnsupportedParam));
             };
 
             if !verify_rsa_pss(public, &bytes, &sig, pkcs_sig.hashing_algorithm())? {
@@ -371,7 +371,7 @@ pub fn checkquote(
             hash_alg = Some(pkcs_sig.hashing_algorithm());
         }
         _ => {
-            return Ok(false);
+            return Err(Error::WrapperError(WrapperErrorKind::UnsupportedParam));
         }
     };
 

--- a/tss-esapi/src/utils/quote.rs
+++ b/tss-esapi/src/utils/quote.rs
@@ -1,0 +1,300 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use crate::error::Error;
+use crate::error::Result;
+use crate::WrapperErrorKind;
+use crate::{
+    interface_types::algorithm::HashingAlgorithm,
+    structures::{Attest, AttestInfo, DigestList, PcrSelectionList, Public, QuoteInfo, Signature},
+    traits::Marshall,
+    utils::PublicKey,
+};
+use digest::{Digest, DynDigest};
+
+#[cfg(feature = "p256")]
+use crate::structures::EccSignature;
+#[cfg(feature = "p256")]
+use p256::ecdsa::{Signature as SignatureP256, VerifyingKey};
+#[cfg(feature = "p256")]
+use signature::{hazmat::PrehashVerifier, Verifier};
+
+#[cfg(feature = "rsa")]
+use crate::structures::RsaSignature;
+#[cfg(feature = "rsa")]
+use rsa::{pss::Pss, RsaPublicKey};
+
+#[cfg(feature = "p256")]
+fn verify_p256(public: &Public, message: &[u8], signature: &EccSignature) -> Result<bool> {
+    let public_key = PublicKey::try_from(public.clone())?;
+    let (x, y) = match public_key {
+        PublicKey::Ecc { x, y } => (x, y),
+        _ => {
+            return Err(Error::WrapperError(WrapperErrorKind::InvalidParam));
+        }
+    };
+    let mut sec1_bytes = Vec::<u8>::with_capacity(1 + x.len() + y.len());
+    sec1_bytes.push(0x04);
+    sec1_bytes.extend_from_slice(&x);
+    sec1_bytes.extend_from_slice(&y);
+    let verifying_key = match VerifyingKey::from_sec1_bytes(&sec1_bytes) {
+        Ok(s) => s,
+        Err(_) => {
+            return Err(Error::WrapperError(WrapperErrorKind::InvalidParam));
+        }
+    };
+
+    let mut sig_bytes = Vec::with_capacity(64);
+    sig_bytes.extend_from_slice(signature.signature_r().as_ref());
+    sig_bytes.extend_from_slice(signature.signature_s().as_ref());
+    let generic_sig = digest::generic_array::GenericArray::clone_from_slice(&sig_bytes);
+    let sig = match SignatureP256::from_bytes(&generic_sig) {
+        Ok(s) => s,
+        Err(_) => {
+            return Err(Error::WrapperError(WrapperErrorKind::InvalidParam));
+        }
+    };
+
+    let verify_result = match signature.hashing_algorithm() {
+        #[cfg(feature = "sha1")]
+        HashingAlgorithm::Sha1 => {
+            let mut hasher = sha1::Sha1::new();
+            Digest::update(&mut hasher, &message);
+            verifying_key.verify_prehash(&hasher.finalize(), &sig)
+        }
+        #[cfg(feature = "sha2")]
+        HashingAlgorithm::Sha256 => verifying_key.verify(&message, &sig),
+        _ => {
+            return Err(Error::WrapperError(WrapperErrorKind::UnsupportedParam));
+        }
+    };
+    return Ok(match verify_result {
+        Ok(_) => true,
+        Err(_) => false,
+    });
+}
+
+#[cfg(feature = "rsa")]
+fn verify_rsa(public: &Public, message: &[u8], signature: &RsaSignature) -> Result<bool> {
+    let public_key = PublicKey::try_from(public.clone())?;
+    let rsa_key = RsaPublicKey::try_from(&public_key)?;
+    let sig = signature.signature();
+    let mut hasher: Box<dyn DynDigest> = match signature.hashing_algorithm() {
+        #[cfg(feature = "sha1")]
+        HashingAlgorithm::Sha1 => Box::new(sha1::Sha1::new()),
+        #[cfg(feature = "sha2")]
+        HashingAlgorithm::Sha256 => Box::new(sha2::Sha256::new()),
+        _ => {
+            return Err(Error::WrapperError(WrapperErrorKind::UnsupportedParam));
+        }
+    };
+    hasher.update(&message);
+    let hash = hasher.finalize().to_vec();
+
+    let scheme = match signature.hashing_algorithm() {
+        #[cfg(feature = "sha1")]
+        HashingAlgorithm::Sha1 => Pss::new::<sha1::Sha1>(),
+        #[cfg(feature = "sha2")]
+        HashingAlgorithm::Sha256 => Pss::new::<sha2::Sha256>(),
+        _ => {
+            return Err(Error::WrapperError(WrapperErrorKind::UnsupportedParam));
+        }
+    };
+    return Ok(match rsa_key.verify(scheme, &hash, &sig) {
+        Ok(_) => true,
+        Err(_) => false,
+    });
+}
+
+fn checkquote_pcr_digests(
+    quote: &QuoteInfo,
+    selections: &PcrSelectionList,
+    digests: &DigestList,
+    hash_alg: HashingAlgorithm,
+) -> Result<bool> {
+    if selections != quote.pcr_selection() {
+        return Ok(false);
+    }
+    let digests_val = digests.value();
+    let mut digest_pos = 0;
+    let mut hasher: Box<dyn DynDigest> = match hash_alg {
+        #[cfg(feature = "sha1")]
+        HashingAlgorithm::Sha1 => Box::new(sha1::Sha1::new()),
+        #[cfg(feature = "sha2")]
+        HashingAlgorithm::Sha256 => Box::new(sha2::Sha256::new()),
+        _ => {
+            return Err(Error::WrapperError(WrapperErrorKind::UnsupportedParam));
+        }
+    };
+
+    for selection in selections.get_selections() {
+        let sel_count = selection.selected().len();
+        if digest_pos + sel_count > digests.len() {
+            return Err(Error::WrapperError(WrapperErrorKind::WrongParamSize));
+        }
+        for _ in 0..sel_count {
+            hasher.update(&digests_val[digest_pos]);
+            digest_pos += 1;
+        }
+    }
+    if digest_pos != digests.len() {
+        return Err(Error::WrapperError(WrapperErrorKind::WrongParamSize));
+    }
+    let digest = hasher.finalize().to_vec();
+    if digest != quote.pcr_digest().as_bytes() {
+        return Ok(false);
+    }
+    return Ok(true);
+}
+
+/// Verify a quote
+///
+/// # Arguments
+/// * `attest` - Attestation data containing a quote
+/// * `signature` - Signature for the attestation data
+/// * `public` - TPM2 public struct which contains the public key for verification
+/// * `pcr_data` - Optional pcr values to verify
+/// * `qualifying_data` - qualifying_data to verify
+///
+/// # Returns
+/// The command returns a boolean
+///
+/// # Errors
+/// * if the qualifying data provided is too long, a `WrongParamSize` wrapper error will be returned
+///
+/// # Examples
+///
+/// ```rust
+/// # use std::convert::TryFrom;
+/// # use tss_esapi::{
+/// #     attributes::SessionAttributes,
+/// #     abstraction::{ak, ek, AsymmetricAlgorithmSelection},
+/// #     constants::SessionType, Context,
+/// #     interface_types::{
+/// #         algorithm::{HashingAlgorithm, SignatureSchemeAlgorithm},
+/// #         ecc::EccCurve,
+/// #     },
+/// #     structures::{
+/// #         Data, PcrSelectionListBuilder, PcrSlot,
+/// #         SignatureScheme, SymmetricDefinition,
+/// #     },
+/// #     TctiNameConf,
+/// #     utils,
+/// # };
+/// # let mut context =
+/// #     Context::new(
+/// #         TctiNameConf::from_environment_variable().expect("Failed to get TCTI"),
+/// #     ).expect("Failed to create Context");
+/// # let session = context
+/// #     .start_auth_session(
+/// #         None,
+/// #         None,
+/// #         None,
+/// #         SessionType::Hmac,
+/// #         SymmetricDefinition::AES_256_CFB,
+/// #         tss_esapi::interface_types::algorithm::HashingAlgorithm::Sha256,
+/// #     )
+/// #     .expect("Failed to create session")
+/// #     .expect("Received invalid handle");
+/// # let (session_attributes, session_attributes_mask) = SessionAttributes::builder()
+/// #     .with_decrypt(true)
+/// #     .with_encrypt(true)
+/// #     .build();
+/// # context.tr_sess_set_attributes(session, session_attributes, session_attributes_mask)
+/// #     .expect("Failed to set attributes on session");
+/// # context.set_sessions((Some(session), None, None));
+/// # let qualifying_data = vec![0xff; 16];
+/// # let ek_ecc = ek::create_ek_object(
+/// #     &mut context,
+/// #     AsymmetricAlgorithmSelection::Ecc(EccCurve::NistP256),
+/// #     None,
+/// # )
+/// # .unwrap();
+/// # let ak_res = ak::create_ak(
+/// #     &mut context,
+/// #     ek_ecc,
+/// #     HashingAlgorithm::Sha256,
+/// #     AsymmetricAlgorithmSelection::Ecc(EccCurve::NistP256),
+/// #     SignatureSchemeAlgorithm::EcDsa,
+/// #     None,
+/// #     None,
+/// # )
+/// # .unwrap();
+/// # let ak_ecc = ak::load_ak(
+/// #     &mut context,
+/// #     ek_ecc,
+/// #     None,
+/// #     ak_res.out_private,
+/// #     ak_res.out_public.clone(),
+/// # )
+/// # .unwrap();
+/// # let pcr_selection_list = PcrSelectionListBuilder::new()
+/// #     .with_selection(HashingAlgorithm::Sha256, &[PcrSlot::Slot2])
+/// #     .build()
+/// #     .expect("Failed to create PcrSelectionList");
+/// let (attest, signature) = context
+///     .quote(
+///         ak_ecc,
+///         Data::try_from(qualifying_data.clone()).unwrap(),
+///         SignatureScheme::Null,
+///         pcr_selection_list.clone(),
+///     )
+///     .expect("Failed to get a quote");
+/// let (_update_counter, pcr_sel, pcr_data) = context
+///     .execute_without_session(|ctx| ctx.pcr_read(pcr_selection_list))
+///     .unwrap();
+/// let public = ak_res.out_public;
+/// utils::checkquote(
+///     &attest,
+///     &signature,
+///     &public,
+///     &Some((pcr_sel.clone(), pcr_data.clone())),
+///     &qualifying_data
+/// )
+/// .unwrap();
+/// ```
+pub fn checkquote(
+    attest: &Attest,
+    signature: &Signature,
+    public: &Public,
+    pcr_data: &Option<(PcrSelectionList, DigestList)>,
+    qualifying_data: &Vec<u8>,
+) -> Result<bool> {
+    let quote = match attest.attested() {
+        AttestInfo::Quote { info } => info,
+        _ => {
+            return Err(Error::WrapperError(WrapperErrorKind::InvalidParam));
+        }
+    };
+    let bytes = attest.marshall()?;
+    let hash_alg = match signature {
+        #[cfg(feature = "p256")]
+        Signature::EcDsa(sig) => {
+            if !verify_p256(&public, &bytes, &sig)? {
+                return Ok(false);
+            }
+            sig.hashing_algorithm()
+        }
+        #[cfg(feature = "rsa")]
+        Signature::RsaPss(sig) => {
+            if !verify_rsa(&public, &bytes, &sig)? {
+                return Ok(false);
+            }
+            sig.hashing_algorithm()
+        }
+        _ => {
+            return Err(Error::WrapperError(WrapperErrorKind::UnsupportedParam));
+        }
+    };
+    if qualifying_data != attest.extra_data().as_bytes() {
+        return Ok(false);
+    }
+    match pcr_data {
+        Some((selections, digests)) => {
+            if !checkquote_pcr_digests(&quote, &selections, &digests, hash_alg)? {
+                return Ok(false);
+            }
+        }
+        None => {}
+    }
+    return Ok(true);
+}

--- a/tss-esapi/src/utils/quote.rs
+++ b/tss-esapi/src/utils/quote.rs
@@ -45,7 +45,6 @@ where
         return Ok(false);
     };
     let Ok(public) = elliptic_curve::PublicKey::<C>::try_from(public) else {
-        println!("public convert failed");
         return Ok(false);
     };
 
@@ -326,16 +325,12 @@ pub fn checkquote(
                         let Signature::EcDsa(sig) = signature else {
                             return Ok(false);
                         };
-                        println!("hash_alg: {:?}", sig.hashing_algorithm());
-
                         if !verify_ecdsa::<$curve>(&public, &bytes, &sig, sig.hashing_algorithm())?
                         {
-                            println!("verification failed");
                             return Ok(false);
                         }
 
                         hash_alg = Some(sig.hashing_algorithm());
-                        println!("hash_alg: {hash_alg:?}");
                     }
                 };
             }

--- a/tss-esapi/src/utils/quote.rs
+++ b/tss-esapi/src/utils/quote.rs
@@ -4,105 +4,150 @@ use crate::error::Error;
 use crate::error::Result;
 use crate::WrapperErrorKind;
 use crate::{
+    abstraction::public::AssociatedTpmCurve,
     interface_types::algorithm::HashingAlgorithm,
-    structures::{Attest, AttestInfo, DigestList, PcrSelectionList, Public, QuoteInfo, Signature},
+    structures::{
+        Attest, AttestInfo, DigestList, EccSignature, PcrSelectionList, Public, QuoteInfo,
+        Signature,
+    },
     traits::Marshall,
-    utils::PublicKey,
 };
 use digest::{Digest, DynDigest};
 
-#[cfg(feature = "p256")]
-use crate::structures::EccSignature;
-#[cfg(feature = "p256")]
-use p256::ecdsa::{Signature as SignatureP256, VerifyingKey};
-#[cfg(feature = "p256")]
+use ecdsa::{
+    hazmat::{DigestPrimitive, VerifyPrimitive},
+    PrimeCurve, SignatureSize, VerifyingKey,
+};
+use elliptic_curve::{
+    generic_array::ArrayLength,
+    point::AffinePoint,
+    sec1::{FromEncodedPoint, ModulusSize, ToEncodedPoint},
+    CurveArithmetic, FieldBytesSize,
+};
 use signature::{hazmat::PrehashVerifier, Verifier};
 
 #[cfg(feature = "rsa")]
-use crate::structures::RsaSignature;
-#[cfg(feature = "rsa")]
-use rsa::{pss::Pss, RsaPublicKey};
+use rsa::{pkcs1v15, pss, RsaPublicKey};
 
-#[cfg(feature = "p256")]
-fn verify_p256(public: &Public, message: &[u8], signature: &EccSignature) -> Result<bool> {
-    let public_key = PublicKey::try_from(public.clone())?;
-    let (x, y) = match public_key {
-        PublicKey::Ecc { x, y } => (x, y),
-        _ => {
-            return Err(Error::WrapperError(WrapperErrorKind::InvalidParam));
-        }
+fn verify_ecdsa<C>(
+    public: &Public,
+    message: &[u8],
+    signature: &EccSignature,
+    hashing_algorithm: HashingAlgorithm,
+) -> Result<bool>
+where
+    C: PrimeCurve + CurveArithmetic + DigestPrimitive + AssociatedTpmCurve,
+    AffinePoint<C>: VerifyPrimitive<C> + FromEncodedPoint<C> + ToEncodedPoint<C>,
+    SignatureSize<C>: ArrayLength<u8>,
+    FieldBytesSize<C>: ModulusSize,
+{
+    let Ok(signature) = ecdsa::Signature::<C>::try_from(signature.clone()) else {
+        return Ok(false);
     };
-    let mut sec1_bytes = Vec::<u8>::with_capacity(1 + x.len() + y.len());
-    sec1_bytes.push(0x04);
-    sec1_bytes.extend_from_slice(&x);
-    sec1_bytes.extend_from_slice(&y);
-    let verifying_key = match VerifyingKey::from_sec1_bytes(&sec1_bytes) {
-        Ok(s) => s,
-        Err(_) => {
-            return Err(Error::WrapperError(WrapperErrorKind::InvalidParam));
-        }
+    let Ok(public) = elliptic_curve::PublicKey::<C>::try_from(public) else {
+        println!("public convert failed");
+        return Ok(false);
     };
 
-    let mut sig_bytes = Vec::with_capacity(64);
-    sig_bytes.extend_from_slice(signature.signature_r().as_ref());
-    sig_bytes.extend_from_slice(signature.signature_s().as_ref());
-    let generic_sig = digest::generic_array::GenericArray::clone_from_slice(&sig_bytes);
-    let sig = match SignatureP256::from_bytes(&generic_sig) {
-        Ok(s) => s,
-        Err(_) => {
-            return Err(Error::WrapperError(WrapperErrorKind::InvalidParam));
-        }
-    };
+    let verifying_key = VerifyingKey::from(public);
 
-    let verify_result = match signature.hashing_algorithm() {
+    match hashing_algorithm {
         #[cfg(feature = "sha1")]
         HashingAlgorithm::Sha1 => {
-            let mut hasher = sha1::Sha1::new();
-            Digest::update(&mut hasher, &message);
-            verifying_key.verify_prehash(&hasher.finalize(), &sig)
+            let hash = sha1::Sha1::digest(&message);
+            Ok(verifying_key.verify_prehash(&hash, &signature).is_ok())
         }
         #[cfg(feature = "sha2")]
-        HashingAlgorithm::Sha256 => verifying_key.verify(&message, &sig),
+        HashingAlgorithm::Sha256 => {
+            let hash = sha2::Sha256::digest(&message);
+            Ok(verifying_key.verify_prehash(&hash, &signature).is_ok())
+        }
+        #[cfg(feature = "sha2")]
+        HashingAlgorithm::Sha384 => {
+            let hash = sha2::Sha384::digest(&message);
+            Ok(verifying_key.verify_prehash(&hash, &signature).is_ok())
+        }
+        #[cfg(feature = "sha2")]
+        HashingAlgorithm::Sha512 => {
+            let hash = sha2::Sha512::digest(&message);
+            Ok(verifying_key.verify_prehash(&hash, &signature).is_ok())
+        }
         _ => {
             return Err(Error::WrapperError(WrapperErrorKind::UnsupportedParam));
         }
-    };
-    return Ok(match verify_result {
-        Ok(_) => true,
-        Err(_) => false,
-    });
+    }
 }
 
 #[cfg(feature = "rsa")]
-fn verify_rsa(public: &Public, message: &[u8], signature: &RsaSignature) -> Result<bool> {
-    let public_key = PublicKey::try_from(public.clone())?;
-    let rsa_key = RsaPublicKey::try_from(&public_key)?;
-    let sig = signature.signature();
-    let mut hasher: Box<dyn DynDigest> = match signature.hashing_algorithm() {
-        #[cfg(feature = "sha1")]
-        HashingAlgorithm::Sha1 => Box::new(sha1::Sha1::new()),
-        #[cfg(feature = "sha2")]
-        HashingAlgorithm::Sha256 => Box::new(sha2::Sha256::new()),
-        _ => {
-            return Err(Error::WrapperError(WrapperErrorKind::UnsupportedParam));
-        }
-    };
-    hasher.update(&message);
-    let hash = hasher.finalize().to_vec();
+fn verify_rsa_pss(
+    public: &Public,
+    message: &[u8],
+    signature: &pss::Signature,
+    hashing_algorithm: HashingAlgorithm,
+) -> Result<bool> {
+    let rsa_key = RsaPublicKey::try_from(public)?;
 
-    let scheme = match signature.hashing_algorithm() {
+    match hashing_algorithm {
         #[cfg(feature = "sha1")]
-        HashingAlgorithm::Sha1 => Pss::new::<sha1::Sha1>(),
+        HashingAlgorithm::Sha1 => {
+            let verifying_key = pss::VerifyingKey::<sha1::Sha1>::from(rsa_key);
+            Ok(verifying_key.verify(message, signature).is_ok())
+        }
         #[cfg(feature = "sha2")]
-        HashingAlgorithm::Sha256 => Pss::new::<sha2::Sha256>(),
+        HashingAlgorithm::Sha256 => {
+            let verifying_key = pss::VerifyingKey::<sha2::Sha256>::from(rsa_key);
+            Ok(verifying_key.verify(message, signature).is_ok())
+        }
+        #[cfg(feature = "sha2")]
+        HashingAlgorithm::Sha384 => {
+            let verifying_key = pss::VerifyingKey::<sha2::Sha384>::from(rsa_key);
+            Ok(verifying_key.verify(message, signature).is_ok())
+        }
+        #[cfg(feature = "sha2")]
+        HashingAlgorithm::Sha512 => {
+            let verifying_key = pss::VerifyingKey::<sha2::Sha512>::from(rsa_key);
+            Ok(verifying_key.verify(message, signature).is_ok())
+        }
         _ => {
             return Err(Error::WrapperError(WrapperErrorKind::UnsupportedParam));
         }
-    };
-    return Ok(match rsa_key.verify(scheme, &hash, &sig) {
-        Ok(_) => true,
-        Err(_) => false,
-    });
+    }
+}
+
+#[cfg(feature = "rsa")]
+fn verify_rsa_pkcs1v15(
+    public: &Public,
+    message: &[u8],
+    signature: &pkcs1v15::Signature,
+    hashing_algorithm: HashingAlgorithm,
+) -> Result<bool> {
+    let rsa_key = RsaPublicKey::try_from(public)?;
+
+    match hashing_algorithm {
+        #[cfg(feature = "sha1")]
+        HashingAlgorithm::Sha1 => {
+            let verifying_key = pkcs1v15::VerifyingKey::<sha1::Sha1>::from(rsa_key);
+            Ok(verifying_key.verify(message, signature).is_ok())
+        }
+        #[cfg(feature = "sha2")]
+        HashingAlgorithm::Sha256 => {
+            let verifying_key = pkcs1v15::VerifyingKey::<sha2::Sha256>::from(rsa_key);
+            Ok(verifying_key.verify(message, signature).is_ok())
+        }
+        #[cfg(feature = "sha2")]
+        HashingAlgorithm::Sha384 => {
+            let verifying_key = pkcs1v15::VerifyingKey::<sha2::Sha384>::from(rsa_key);
+            Ok(verifying_key.verify(message, signature).is_ok())
+        }
+        #[cfg(feature = "sha2")]
+        HashingAlgorithm::Sha512 => {
+            let verifying_key = pkcs1v15::VerifyingKey::<sha2::Sha512>::from(rsa_key);
+            Ok(verifying_key.verify(message, signature).is_ok())
+        }
+        _ => {
+            return Err(Error::WrapperError(WrapperErrorKind::UnsupportedParam));
+        }
+    }
 }
 
 fn checkquote_pcr_digests(
@@ -121,6 +166,10 @@ fn checkquote_pcr_digests(
         HashingAlgorithm::Sha1 => Box::new(sha1::Sha1::new()),
         #[cfg(feature = "sha2")]
         HashingAlgorithm::Sha256 => Box::new(sha2::Sha256::new()),
+        #[cfg(feature = "sha2")]
+        HashingAlgorithm::Sha384 => Box::new(sha2::Sha384::new()),
+        #[cfg(feature = "sha2")]
+        HashingAlgorithm::Sha512 => Box::new(sha2::Sha512::new()),
         _ => {
             return Err(Error::WrapperError(WrapperErrorKind::UnsupportedParam));
         }
@@ -265,25 +314,74 @@ pub fn checkquote(
             return Err(Error::WrapperError(WrapperErrorKind::InvalidParam));
         }
     };
+
     let bytes = attest.marshall()?;
-    let hash_alg = match signature {
-        #[cfg(feature = "p256")]
-        Signature::EcDsa(sig) => {
-            if !verify_p256(&public, &bytes, &sig)? {
-                return Ok(false);
+
+    let mut hash_alg = None;
+    match (public, signature) {
+        (Public::Ecc { parameters, .. }, _) => {
+            macro_rules! impl_check_ecdsa {
+                ($curve: ty) => {
+                    if parameters.ecc_curve() == <$curve>::TPM_CURVE {
+                        let Signature::EcDsa(sig) = signature else {
+                            return Ok(false);
+                        };
+                        println!("hash_alg: {:?}", sig.hashing_algorithm());
+
+                        if !verify_ecdsa::<$curve>(&public, &bytes, &sig, sig.hashing_algorithm())?
+                        {
+                            println!("verification failed");
+                            return Ok(false);
+                        }
+
+                        hash_alg = Some(sig.hashing_algorithm());
+                        println!("hash_alg: {hash_alg:?}");
+                    }
+                };
             }
-            sig.hashing_algorithm()
+
+            //#[cfg(feature = "p192")]
+            //impl_check_ecdsa!(p192::NistP192);
+            #[cfg(feature = "p224")]
+            impl_check_ecdsa!(p224::NistP224);
+            #[cfg(feature = "p256")]
+            impl_check_ecdsa!(p256::NistP256);
+            #[cfg(feature = "p384")]
+            impl_check_ecdsa!(p384::NistP384);
+            //#[cfg(feature = "p521")]
+            //impl_check_ecdsa!(p521::NistP521);
+            //#[cfg(feature = "sm2")]
+            //impl_check_ecdsa!(sm2::Sm2);
         }
         #[cfg(feature = "rsa")]
-        Signature::RsaPss(sig) => {
-            if !verify_rsa(&public, &bytes, &sig)? {
+        (Public::Rsa { .. }, sig @ Signature::RsaSsa(pkcs_sig)) => {
+            let Ok(sig) = pkcs1v15::Signature::try_from(sig.clone()) else {
+                return Ok(false);
+            };
+
+            if !verify_rsa_pkcs1v15(public, &bytes, &sig, pkcs_sig.hashing_algorithm())? {
                 return Ok(false);
             }
-            sig.hashing_algorithm()
+            hash_alg = Some(pkcs_sig.hashing_algorithm());
+        }
+        #[cfg(feature = "rsa")]
+        (Public::Rsa { .. }, sig @ Signature::RsaPss(pkcs_sig)) => {
+            let Ok(sig) = pss::Signature::try_from(sig.clone()) else {
+                return Ok(false);
+            };
+
+            if !verify_rsa_pss(public, &bytes, &sig, pkcs_sig.hashing_algorithm())? {
+                return Ok(false);
+            }
+            hash_alg = Some(pkcs_sig.hashing_algorithm());
         }
         _ => {
-            return Err(Error::WrapperError(WrapperErrorKind::UnsupportedParam));
+            return Ok(false);
         }
+    };
+
+    let Some(hash_alg) = hash_alg else {
+        return Ok(false);
     };
     if qualifying_data != attest.extra_data().as_bytes() {
         return Ok(false);

--- a/tss-esapi/src/utils/quote.rs
+++ b/tss-esapi/src/utils/quote.rs
@@ -125,22 +125,22 @@ fn verify_rsa_pkcs1v15(
     match hashing_algorithm {
         #[cfg(feature = "sha1")]
         HashingAlgorithm::Sha1 => {
-            let verifying_key = pkcs1v15::VerifyingKey::<sha1::Sha1>::from(rsa_key);
+            let verifying_key = pkcs1v15::VerifyingKey::<sha1::Sha1>::new(rsa_key);
             Ok(verifying_key.verify(message, signature).is_ok())
         }
         #[cfg(feature = "sha2")]
         HashingAlgorithm::Sha256 => {
-            let verifying_key = pkcs1v15::VerifyingKey::<sha2::Sha256>::from(rsa_key);
+            let verifying_key = pkcs1v15::VerifyingKey::<sha2::Sha256>::new(rsa_key);
             Ok(verifying_key.verify(message, signature).is_ok())
         }
         #[cfg(feature = "sha2")]
         HashingAlgorithm::Sha384 => {
-            let verifying_key = pkcs1v15::VerifyingKey::<sha2::Sha384>::from(rsa_key);
+            let verifying_key = pkcs1v15::VerifyingKey::<sha2::Sha384>::new(rsa_key);
             Ok(verifying_key.verify(message, signature).is_ok())
         }
         #[cfg(feature = "sha2")]
         HashingAlgorithm::Sha512 => {
-            let verifying_key = pkcs1v15::VerifyingKey::<sha2::Sha512>::from(rsa_key);
+            let verifying_key = pkcs1v15::VerifyingKey::<sha2::Sha512>::new(rsa_key);
             Ok(verifying_key.verify(message, signature).is_ok())
         }
         _ => {

--- a/tss-esapi/tests/integration_tests/utils_tests/mod.rs
+++ b/tss-esapi/tests/integration_tests/utils_tests/mod.rs
@@ -1,3 +1,4 @@
 // Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 mod get_tpm_vendor_test;
+mod quote_test;

--- a/tss-esapi/tests/integration_tests/utils_tests/quote_test.rs
+++ b/tss-esapi/tests/integration_tests/utils_tests/quote_test.rs
@@ -1,0 +1,263 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+
+mod test_quote {
+    use crate::common::create_ctx_with_session;
+    use std::convert::TryFrom;
+    use tss_esapi::{
+        abstraction::{ak, ek, AsymmetricAlgorithmSelection},
+        handles::PcrHandle,
+        interface_types::{
+            algorithm::{HashingAlgorithm, SignatureSchemeAlgorithm},
+            ecc::EccCurve,
+            key_bits::RsaKeyBits,
+        },
+        structures::{
+            Auth, Data, Digest, DigestList, DigestValues, EccSignature, PcrSelectionListBuilder,
+            PcrSlot, Signature, SignatureScheme,
+        },
+        utils,
+    };
+
+    fn checkquote_ecc(hash_alg: HashingAlgorithm) {
+        let mut context = create_ctx_with_session();
+        let ek_ecc = ek::create_ek_object(
+            &mut context,
+            AsymmetricAlgorithmSelection::Ecc(EccCurve::NistP256),
+            None,
+        )
+        .unwrap();
+        // change pcr values for tests
+        let mut vals = DigestValues::new();
+        vals.set(
+            HashingAlgorithm::Sha256,
+            Digest::try_from(vec![
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+                24, 25, 26, 27, 28, 29, 30, 31, 32,
+            ])
+            .unwrap(),
+        );
+        context.pcr_extend(PcrHandle::Pcr7, vals).unwrap();
+
+        let ak_res = ak::create_ak(
+            &mut context,
+            ek_ecc,
+            hash_alg,
+            AsymmetricAlgorithmSelection::Ecc(EccCurve::NistP256),
+            SignatureSchemeAlgorithm::EcDsa,
+            None,
+            None,
+        )
+        .unwrap();
+        let ak_ecc = ak::load_ak(
+            &mut context,
+            ek_ecc,
+            None,
+            ak_res.out_private,
+            ak_res.out_public.clone(),
+        )
+        .unwrap();
+
+        let pcr_selection_list = PcrSelectionListBuilder::new()
+            .with_selection(HashingAlgorithm::Sha1, &[PcrSlot::Slot4])
+            .with_selection(HashingAlgorithm::Sha256, &[PcrSlot::Slot2])
+            .with_selection(HashingAlgorithm::Sha256, &[PcrSlot::Slot7])
+            .with_selection(HashingAlgorithm::Sha512, &[PcrSlot::Slot4])
+            .build()
+            .expect("Failed to create PcrSelectionList");
+        let qualifying_data = vec![5, 2, 3, 8, 1, 4, 8, 28, 1, 4, 8, 2];
+        let (attest, signature) = context
+            .quote(
+                ak_ecc,
+                Data::try_from(qualifying_data.clone()).unwrap(),
+                SignatureScheme::Null,
+                pcr_selection_list.clone(),
+            )
+            .expect("Failed to get a quote");
+        let (_update_counter, pcr_sel, pcr_data) = context
+            .execute_without_session(|ctx| ctx.pcr_read(pcr_selection_list))
+            .unwrap();
+
+        let public = ak_res.out_public;
+        assert_eq!(
+            utils::checkquote(
+                &attest,
+                &signature,
+                &public,
+                &Some((pcr_sel.clone(), pcr_data.clone())),
+                &qualifying_data
+            )
+            .unwrap(),
+            true
+        );
+        // Test without pcrs
+        assert_eq!(
+            utils::checkquote(&attest, &signature, &public, &None, &qualifying_data).unwrap(),
+            true
+        );
+
+        let wrong_nonce = vec![5, 2, 3, 8, 1, 4, 8];
+        assert_eq!(
+            utils::checkquote(&attest, &signature, &public, &None, &wrong_nonce).unwrap(),
+            false
+        );
+
+        let wrong_ak_res = ak::create_ak(
+            &mut context,
+            ek_ecc,
+            hash_alg,
+            AsymmetricAlgorithmSelection::Ecc(EccCurve::NistP256),
+            SignatureSchemeAlgorithm::EcDsa,
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            utils::checkquote(
+                &attest,
+                &signature,
+                &wrong_ak_res.out_public,
+                &Some((pcr_sel.clone(), pcr_data.clone())),
+                &qualifying_data
+            )
+            .unwrap(),
+            false
+        );
+
+        let wrong_selection = PcrSelectionListBuilder::new()
+            .with_selection(HashingAlgorithm::Sha1, &[PcrSlot::Slot4])
+            .with_selection(HashingAlgorithm::Sha256, &[PcrSlot::Slot2])
+            .build()
+            .expect("Failed to create PcrSelectionList");
+        assert_eq!(
+            utils::checkquote(
+                &attest,
+                &signature,
+                &public,
+                &Some((wrong_selection, pcr_data.clone())),
+                &qualifying_data
+            )
+            .unwrap(),
+            false
+        );
+
+        let mut wrong_pcr_data = DigestList::new();
+        for i in 1..pcr_data.len() {
+            wrong_pcr_data.add(pcr_data.value()[i].clone()).unwrap();
+        }
+        wrong_pcr_data.add(pcr_data.value()[0].clone()).unwrap();
+        assert_eq!(
+            utils::checkquote(
+                &attest,
+                &signature,
+                &public,
+                &Some((pcr_sel.clone(), wrong_pcr_data)),
+                &qualifying_data
+            )
+            .unwrap(),
+            false
+        );
+
+        let ecc = match signature {
+            Signature::EcDsa(e) => e,
+            _ => {
+                panic!("Wrong signature created");
+            }
+        };
+        let wrong_signature = EccSignature::create(
+            HashingAlgorithm::Sha256,
+            ecc.signature_s().clone(),
+            ecc.signature_r().clone(),
+        )
+        .unwrap();
+        assert_eq!(
+            utils::checkquote(
+                &attest,
+                &Signature::EcDsa(wrong_signature),
+                &public,
+                &Some((pcr_sel.clone(), pcr_data.clone())),
+                &qualifying_data
+            )
+            .unwrap(),
+            false
+        );
+    }
+
+    #[test]
+    fn checkquote_ecc_sha1() {
+        checkquote_ecc(HashingAlgorithm::Sha1);
+    }
+
+    #[test]
+    fn checkquote_ecc_sha256() {
+        checkquote_ecc(HashingAlgorithm::Sha256);
+    }
+
+    fn checkquote_rsa(keybits: RsaKeyBits, hash_alg: HashingAlgorithm) {
+        let mut context = create_ctx_with_session();
+        let ek_rsa = ek::create_ek_object(
+            &mut context,
+            AsymmetricAlgorithmSelection::Rsa(RsaKeyBits::Rsa2048),
+            None,
+        )
+        .unwrap();
+        let ak_auth = Auth::try_from(vec![0x1, 0x2, 0x42]).unwrap();
+        let ak_rsa = ak::create_ak(
+            &mut context,
+            ek_rsa,
+            hash_alg,
+            AsymmetricAlgorithmSelection::Rsa(keybits),
+            SignatureSchemeAlgorithm::RsaPss,
+            Some(ak_auth.clone()),
+            None,
+        )
+        .unwrap();
+        let loaded_ak = ak::load_ak(
+            &mut context,
+            ek_rsa,
+            Some(ak_auth),
+            ak_rsa.out_private,
+            ak_rsa.out_public.clone(),
+        )
+        .unwrap();
+
+        let pcr_selection_list = PcrSelectionListBuilder::new()
+            .with_selection(HashingAlgorithm::Sha256, &[PcrSlot::Slot7])
+            .build()
+            .expect("Failed to create PcrSelectionList");
+        let qualifying_data = vec![5, 8, 1, 4, 8, 28, 18, 4, 8, 2];
+        let (attest, signature) = context
+            .quote(
+                loaded_ak,
+                Data::try_from(qualifying_data.clone()).unwrap(),
+                SignatureScheme::Null,
+                pcr_selection_list.clone(),
+            )
+            .expect("Failed to get a quote");
+        let (_update_counter, pcr_sel, pcr_data) = context
+            .execute_without_session(|ctx| ctx.pcr_read(pcr_selection_list))
+            .unwrap();
+
+        assert_eq!(
+            utils::checkquote(
+                &attest,
+                &signature,
+                &ak_rsa.out_public,
+                &Some((pcr_sel.clone(), pcr_data.clone())),
+                &qualifying_data
+            )
+            .unwrap(),
+            true
+        );
+    }
+
+    #[test]
+    fn checkquote_rsa_sha1() {
+        checkquote_rsa(RsaKeyBits::Rsa2048, HashingAlgorithm::Sha1);
+    }
+
+    #[test]
+    fn checkquote_rsa_sha256() {
+        checkquote_rsa(RsaKeyBits::Rsa3072, HashingAlgorithm::Sha256);
+    }
+}

--- a/tss-esapi/tests/integration_tests/utils_tests/quote_test.rs
+++ b/tss-esapi/tests/integration_tests/utils_tests/quote_test.rs
@@ -193,7 +193,16 @@ mod test_quote {
         checkquote_ecc(HashingAlgorithm::Sha256);
     }
 
-    fn checkquote_rsa(keybits: RsaKeyBits, hash_alg: HashingAlgorithm) {
+    #[test]
+    fn checkquote_ecc_sha512() {
+        checkquote_ecc(HashingAlgorithm::Sha512);
+    }
+
+    fn checkquote_rsa(
+        keybits: RsaKeyBits,
+        hash_alg: HashingAlgorithm,
+        sig_scheme: SignatureSchemeAlgorithm,
+    ) {
         let mut context = create_ctx_with_session();
         let ek_rsa = ek::create_ek_object(
             &mut context,
@@ -207,7 +216,7 @@ mod test_quote {
             ek_rsa,
             hash_alg,
             AsymmetricAlgorithmSelection::Rsa(keybits),
-            SignatureSchemeAlgorithm::RsaPss,
+            sig_scheme,
             Some(ak_auth.clone()),
             None,
         )
@@ -252,17 +261,29 @@ mod test_quote {
     }
 
     #[test]
-    fn checkquote_rsa_sha1() {
-        checkquote_rsa(RsaKeyBits::Rsa2048, HashingAlgorithm::Sha1);
+    fn checkquote_rsa_pss_sha1() {
+        checkquote_rsa(
+            RsaKeyBits::Rsa1024,
+            HashingAlgorithm::Sha1,
+            SignatureSchemeAlgorithm::RsaPss,
+        );
     }
 
     #[test]
-    fn checkquote_rsa_sha256() {
-        checkquote_rsa(RsaKeyBits::Rsa3072, HashingAlgorithm::Sha256);
+    fn checkquote_rsa_ssa_sha256() {
+        checkquote_rsa(
+            RsaKeyBits::Rsa2048,
+            HashingAlgorithm::Sha256,
+            SignatureSchemeAlgorithm::RsaSsa,
+        );
     }
 
     #[test]
-    fn checkquote_rsa_sha384() {
-        checkquote_rsa(RsaKeyBits::Rsa3072, HashingAlgorithm::Sha384);
+    fn checkquote_rsa_pss_sha384() {
+        checkquote_rsa(
+            RsaKeyBits::Rsa3072,
+            HashingAlgorithm::Sha384,
+            SignatureSchemeAlgorithm::RsaPss,
+        );
     }
 }

--- a/tss-esapi/tests/integration_tests/utils_tests/quote_test.rs
+++ b/tss-esapi/tests/integration_tests/utils_tests/quote_test.rs
@@ -260,4 +260,9 @@ mod test_quote {
     fn checkquote_rsa_sha256() {
         checkquote_rsa(RsaKeyBits::Rsa3072, HashingAlgorithm::Sha256);
     }
+
+    #[test]
+    fn checkquote_rsa_sha384() {
+        checkquote_rsa(RsaKeyBits::Rsa3072, HashingAlgorithm::Sha384);
+    }
 }


### PR DESCRIPTION
Behavor of `rsa::pkcs1v15::VerifyingKey::from` changes in the next release of rsa. It changes from an unprefixed to a prefixed verification key.

In any case, the best option is to be explicit and use the `VerifyingKey::new` and force the prefixed version.